### PR TITLE
Jep/atomdata vault and datacontainers

### DIFF
--- a/waxa-src/waxa/atomdata_vault.py
+++ b/waxa-src/waxa/atomdata_vault.py
@@ -2,17 +2,34 @@
 analysis object.
 
 Intended use case: a 1-D scan was broken across multiple runs to keep per-file
-sizes manageable. AtomdataVault stitches the chunks back together so the
-combined dataset can be analyzed with the usual atomdata interface
-(``vault.atom_number``, ``vault.od``, ``vault.fit_sd_x``, ``vault.data.*``,
-etc.) without ever re-saving anything to disk.
+sizes manageable, or an *experiment builder* launched many runs that each scan
+the **same xvar over a different range**. AtomdataVault stitches the chunks back
+together so the combined dataset can be analyzed with the usual atomdata
+interface (``vault.atom_number``, ``vault.od``, ``vault.fit_sd_x``,
+``vault.data.*``, etc.) without ever re-saving anything to disk.
 
-Limitations (v1):
+Key capabilities:
+    * Ragged-repeat-aware statistics. ``vault.avg`` / ``vault.std`` / ``vault.sem``
+      group by unique xvar value, so overlapping ranges (where some points are
+      sampled more often than others) average correctly. SEM uses each point's
+      own repeat count. See ``collapse_to_unique`` to bake the grouping in.
+    * Per-shot provenance. ``vault.shot_run_id`` records which source run each
+      shot came from (carried through the internal sort), enabling drift plots
+      coloured by run, ``shots_from_run``, and ``drop_runs``.
+    * Memory controls for large jobs: ``auto_lite_threshold`` and
+      ``drop_raw_images`` keep many-run loads tractable.
+    * Builder-aware discovery: ``AtomdataVault.from_run_range`` /
+      ``from_builder`` enumerate a contiguous run-id range (optionally filtered
+      by experiment name) and skip missing/aborted runs.
+    * Incremental growth (``add_runs``) and a per-run parameter audit
+      (``param_report``).
+
+Limitations:
     * Only 1-D scans are supported. Every input must have ``Nvars == 1``.
     * All inputs must share the same ``xvarnames[0]`` unless
       ``xvarname_override=True``.
-    * All inputs must share ``N_repeats``, ``imaging_type``, and per-shot
-      image shape.
+    * All inputs must share ``imaging_type`` and per-shot image shape.
+      ``N_repeats`` may now differ across inputs (see ``merge_overlap``).
     * Shuffling, reassigning repeats, and transposing are disabled on the
       resulting vault.
 """
@@ -86,6 +103,20 @@ class AtomdataVault(atomdata_base):
     sort : bool
         If True (default), the concatenated xvar axis is sorted ascending
         (stable) and every per-shot array is reindexed accordingly.
+    merge_overlap : bool
+        If True (default), ``vault.avg`` / ``vault.std`` / ``vault.sem`` group
+        shots by unique xvar value rather than by a fixed repeat count. This is
+        what makes overlapping ranges with ragged repeat counts average
+        correctly. If False, the base (uniform-repeat) statistics are used and
+        ragged counts fall back to a passthrough mean with zero spread.
+    drop_raw_images : bool
+        If True, free the (large) raw image stack after the initial analysis
+        completes, keeping only derived quantities (``od``, ``atom_number``,
+        fits, ...). Useful for many-run jobs. Defaults to False.
+    auto_lite_threshold : int or None
+        If set and more than this many run-ids are passed (and ``lite`` is
+        False), automatically load them ``lite`` and emit a warning. Defaults
+        to 8. Pass ``None`` to disable.
     """
 
     def __init__(self,
@@ -93,13 +124,30 @@ class AtomdataVault(atomdata_base):
                  roi_id=None,
                  lite=False,
                  xvarname_override=False,
-                 sort=True):
+                 sort=True,
+                 merge_overlap=True,
+                 drop_raw_images=False,
+                 auto_lite_threshold=8):
 
         # Lightweight book-keeping expected by inherited helpers.
         self._lite = lite
         self._timing_enabled = False
         self._timing = {}
         self.server_talk = None
+
+        # Vault-specific configuration.
+        self._merge_overlap = bool(merge_overlap)
+        self._drop_raw_images = bool(drop_raw_images)
+        # Kwargs needed to rebuild an equivalent vault (used by add_runs).
+        self._build_kwargs = dict(
+            roi_id=roi_id,
+            lite=lite,
+            xvarname_override=xvarname_override,
+            sort=sort,
+            merge_overlap=merge_overlap,
+            drop_raw_images=drop_raw_images,
+            auto_lite_threshold=auto_lite_threshold,
+        )
 
         self.avg: Optional[atomdata_base] = None
         self.std: Optional[atomdata_base] = None
@@ -110,11 +158,32 @@ class AtomdataVault(atomdata_base):
         self._repeat_lazy_stat_context = None
         self._data_file_path = None
         self._saved_roi_from_file = False
+        # Per-run parameter audit, filled in by _warn_param_mismatches.
+        self.param_disagreements = {}
 
         # 1. Normalize and materialize inputs.
         raw_inputs = _flatten_inputs(inputs)
         if len(raw_inputs) == 0:
             raise ValueError("AtomdataVault requires at least one input.")
+
+        # Memory guard: when many run-ids are requested, default to loading the
+        # pre-cropped lite datasets unless the caller explicitly opted out.
+        n_int_inputs = sum(
+            isinstance(item, (int, np.integer)) for item in raw_inputs
+        )
+        if (auto_lite_threshold is not None
+                and not lite
+                and n_int_inputs > int(auto_lite_threshold)):
+            warnings.warn(
+                f"AtomdataVault: loading {n_int_inputs} run-ids; switching to "
+                f"lite datasets to limit memory (auto_lite_threshold="
+                f"{auto_lite_threshold}). Pass auto_lite_threshold=None to "
+                f"disable, or lite=True to silence.",
+                stacklevel=2,
+            )
+            lite = True
+            self._lite = True
+            self._build_kwargs['lite'] = True
 
         # Load run-ids sequentially so that only the first load can trigger
         # the ROI selection GUI. After the first run is loaded (or if the
@@ -157,19 +226,28 @@ class AtomdataVault(atomdata_base):
                     f"run_id ints, got {type(item).__name__}."
                 )
 
-        # 2. Validate compatibility.
-        self._validate_inputs(ads, xvarname_override)
+        # 2. Validate compatibility. N_repeats may differ across inputs when
+        #    merge_overlap is on (grouped statistics handle ragged counts).
+        self._validate_inputs(
+            ads, xvarname_override,
+            allow_repeat_mismatch=self._merge_overlap,
+        )
 
-        # 3. Deep-copy and unshuffle each chunk so the caller's handles are
-        #    untouched and the per-shot arrays are in xvar order on axis 0.
+        # 3. Unshuffle each chunk so the per-shot arrays are in xvar order on
+        #    axis 0. Only chunks that actually need unshuffling are deep-copied
+        #    (unshuffle mutates in place); already-ordered chunks are used
+        #    by-reference and only read from, which avoids duplicating large
+        #    image stacks for the common many-run / lite case.
         chunks = []
         for ad in ads:
-            ad_copy = copy.deepcopy(ad)
-            if getattr(ad_copy._analysis_tags, 'xvars_shuffled', False):
+            if getattr(ad._analysis_tags, 'xvars_shuffled', False):
+                ad_copy = copy.deepcopy(ad)
                 ad_copy.unshuffle(reanalyze=False)
                 if getattr(ad_copy, '_has_images', True):
                     ad_copy._sort_images()
-            chunks.append(ad_copy)
+                chunks.append(ad_copy)
+            else:
+                chunks.append(ad)
 
         # 4. Assemble vault state from chunks.
         first = chunks[0]
@@ -190,6 +268,15 @@ class AtomdataVault(atomdata_base):
         xvar_values = np.concatenate(
             [np.asarray(c.xvars[0]) for c in chunks], axis=0
         )
+
+        # Per-shot provenance: which source run each concatenated shot came
+        # from. Carried through the sort/reindex below so it always lines up
+        # with the analyzed arrays.
+        self.shot_run_id = np.concatenate([
+            np.full(int(np.asarray(c.xvars[0]).shape[0]),
+                    int(c.run_info.run_id), dtype=np.int64)
+            for c in chunks
+        ])
 
         # Concatenate images / timestamps if present.
         # Keep a reference to the first chunk's raw images so the ROI GUI
@@ -274,10 +361,30 @@ class AtomdataVault(atomdata_base):
         # 7. Run the standard initial analysis pipeline.
         self._initial_analysis(transpose_idx=[], avg_repeats=False)
 
+        # 8. Optionally free the raw image stack now that derived quantities
+        #    (od, atom_number, fits, ...) have been computed.
+        if self._drop_raw_images and self._has_images:
+            self.images = np.array([])
+            self.image_timestamps = np.array([])
+
+    def _initial_analysis(self, transpose_idx, avg_repeats):
+        """Mirror ``atomdata._initial_analysis``: skip all image-based analysis
+        for runs that captured no camera images (e.g. APD/scope-only runs),
+        otherwise defer to the standard base pipeline."""
+        if not getattr(self, '_has_images', True):
+            for attr in ('img_atoms', 'img_light', 'img_dark',
+                         'od_raw', 'od', 'sum_od_x', 'sum_od_y',
+                         'integrated_od', 'atom_number',
+                         'cloudfit_x', 'cloudfit_y'):
+                setattr(self, attr, None)
+            self._refresh_repeat_statistics()
+            return
+        return atomdata_base._initial_analysis(self, transpose_idx, avg_repeats)
+
     # ------------------------------------------------------------------
     # Validation helpers
     # ------------------------------------------------------------------
-    def _validate_inputs(self, ads, xvarname_override):
+    def _validate_inputs(self, ads, xvarname_override, allow_repeat_mismatch=False):
         first = ads[0]
 
         if int(getattr(first, 'Nvars', 0)) != 1:
@@ -295,6 +402,8 @@ class AtomdataVault(atomdata_base):
             if first_has_images else None
         )
 
+        repeat_counts = {int(first.run_info.run_id): first_nrep}
+
         for ad in ads[1:]:
             if int(getattr(ad, 'Nvars', 0)) != 1:
                 raise ValueError(
@@ -308,11 +417,14 @@ class AtomdataVault(atomdata_base):
                     f"'{name}' but first input has '{first_name}'. "
                     f"Pass xvarname_override=True to override."
                 )
-            if int(ad.params.N_repeats) != first_nrep:
+            ad_nrep = int(ad.params.N_repeats)
+            repeat_counts[int(ad.run_info.run_id)] = ad_nrep
+            if ad_nrep != first_nrep and not allow_repeat_mismatch:
                 raise ValueError(
                     f"N_repeats mismatch: run {ad.run_info.run_id} has "
                     f"N_repeats={ad.params.N_repeats} but first input has "
-                    f"N_repeats={first_nrep}."
+                    f"N_repeats={first_nrep}. Pass merge_overlap=True (the "
+                    f"default) to allow ragged repeat counts."
                 )
             if ad.run_info.imaging_type != first_imgtype:
                 raise ValueError(
@@ -342,41 +454,56 @@ class AtomdataVault(atomdata_base):
                     stacklevel=2,
                 )
 
+        # Record per-run repeat counts for the parameter audit.
+        self.source_repeat_counts = repeat_counts
+
     def _warn_param_mismatches(self, chunks):
         """Emit a single warning summarizing fixed-param disagreements
-        across chunks (excluding the scanned xvar itself)."""
+        across chunks (excluding the scanned xvar itself) and record the
+        per-run values in ``self.param_disagreements`` for ``param_report``."""
         first = chunks[0]
         first_params = vars(first.params)
         xvarname = _decode_xvarname(first.xvarnames[0])
 
+        def _equalish(a_val, b_val):
+            try:
+                if isinstance(a_val, np.ndarray) or isinstance(b_val, np.ndarray):
+                    a = np.asarray(a_val)
+                    b = np.asarray(b_val)
+                    return a.shape == b.shape and np.array_equal(a, b)
+                return a_val == b_val
+            except Exception:
+                # Non-comparable params are treated as "equal" (skipped).
+                return True
+
         mismatched = []
+        disagreements = {}
         for key, first_val in first_params.items():
             if key.startswith('_') or key == xvarname:
                 continue
+            differs = False
             for c in chunks[1:]:
                 other = vars(c.params).get(key, None)
                 if other is None:
                     continue
-                try:
-                    if isinstance(first_val, np.ndarray) or isinstance(other, np.ndarray):
-                        a = np.asarray(first_val)
-                        b = np.asarray(other)
-                        if a.shape != b.shape or not np.array_equal(a, b):
-                            mismatched.append(key)
-                            break
-                    else:
-                        if first_val != other:
-                            mismatched.append(key)
-                            break
-                except Exception:
-                    # Non-comparable params are silently skipped.
-                    continue
+                if not _equalish(first_val, other):
+                    differs = True
+                    break
+            if differs:
+                mismatched.append(key)
+                disagreements[key] = {
+                    int(c.run_info.run_id): vars(c.params).get(key, None)
+                    for c in chunks
+                }
+
+        self.param_disagreements = disagreements
 
         if mismatched:
             warnings.warn(
                 "AtomdataVault: fixed parameters disagree across input runs "
                 "(using values from the first run): "
-                + ", ".join(sorted(set(mismatched))),
+                + ", ".join(sorted(set(mismatched)))
+                + ". Call vault.param_report() for a per-run breakdown.",
                 stacklevel=2,
             )
 
@@ -500,41 +627,506 @@ class AtomdataVault(atomdata_base):
         order = np.argsort(xvar_values, kind='stable')
         if np.array_equal(order, np.arange(len(xvar_values))):
             return  # already sorted
+        self._reorder_shots(order)
 
-        xvar_values = xvar_values[order]
-        self.xvars[0] = xvar_values
-        setattr(self.params, self.xvarnames[0], xvar_values)
+    def _reorder_shots(self, order):
+        """Reindex every per-shot quantity along axis 0 by ``order``.
 
-        if self._has_images:
+        ``order`` is an array of source shot-indices to keep (in the desired
+        new order). Used both for the construction-time sort (a permutation)
+        and for ``drop_runs`` (a subset). Handles the merged xvar, per-shot
+        provenance, raw interleaved or 1-per-shot images, DataVault arrays,
+        scope traces, and any top-level scan-shaped analysis arrays
+        (``od_raw``, ``atom_number``, ...) that already exist.
+        """
+        order = np.asarray(order, dtype=int)
+        n_old = int(np.asarray(self.xvars[0]).shape[0])
+        n_new = int(order.shape[0])
+
+        # Merged xvar + scanned param.
+        self.xvars[0] = np.asarray(self.xvars[0])[order]
+        setattr(self.params, self.xvarnames[0], self.xvars[0])
+
+        # Per-shot provenance.
+        if hasattr(self, 'shot_run_id'):
+            self.shot_run_id = np.asarray(self.shot_run_id)[order]
+
+        # Images / timestamps (raw interleaved or 1-per-shot).
+        if self._has_images and np.asarray(self.images).size:
             Nf = int(self.params.N_pwa_per_shot) + 2
-            n_shots = len(order)
-            if self.images.shape[0] == n_shots * Nf:
-                # Raw interleaved: (N_shots * Nf, H, W). Sort in groups of Nf
-                # so that each shot's (atoms, light, dark) frames stay together.
-                frame_order = np.concatenate(
-                    [np.arange(i * Nf, (i + 1) * Nf) for i in order]
-                )
+            if self.images.shape[0] == n_old * Nf:
+                if n_new:
+                    frame_order = np.concatenate(
+                        [np.arange(i * Nf, (i + 1) * Nf) for i in order]
+                    )
+                else:
+                    frame_order = np.array([], dtype=int)
                 self.images = self.images[frame_order]
                 self.image_timestamps = self.image_timestamps[frame_order]
-            else:
-                # Already 1 image per shot (lite or special mode).
+            elif self.images.shape[0] == n_old:
                 self.images = self.images[order]
                 self.image_timestamps = self.image_timestamps[order]
 
+        # DataVault arrays.
         for k in self.data.keys:
             arr = vars(self.data)[k]
-            if isinstance(arr, np.ndarray) and arr.ndim >= 1 and arr.shape[0] == len(order):
+            if isinstance(arr, np.ndarray) and arr.ndim >= 1 and arr.shape[0] == n_old:
                 vars(self.data)[k] = arr[order]
 
+        # Scope traces.
         if hasattr(self, 'scope_data'):
             for scope_key, ch_dict in self.scope_data.items():
                 for ch, trace in ch_dict.items():
                     t = np.asarray(trace.t)
                     v = np.asarray(trace.v)
-                    if t.ndim >= 1 and t.shape[0] == len(order):
+                    if t.ndim >= 1 and t.shape[0] == n_old:
                         trace.t = t[order]
-                    if v.ndim >= 1 and v.shape[0] == len(order):
+                    if v.ndim >= 1 and v.shape[0] == n_old:
                         trace.v = v[order]
+
+        # Top-level scan-shaped analysis arrays (present post-analysis).
+        _skip = {'images', 'image_timestamps', 'shot_run_id'}
+        for key, val in list(vars(self).items()):
+            if key in _skip or key.startswith('_'):
+                continue
+            if isinstance(val, np.ndarray) and val.ndim >= 1 and val.shape[0] == n_old:
+                vars(self)[key] = val[order]
+
+        # Update shot-count bookkeeping (matters when n_new != n_old).
+        self.xvardims = np.array([n_new], dtype=int)
+        nrep = int(getattr(self.params, 'N_repeats', 1) or 1)
+        self.params.N_shots_with_repeats = n_new
+        if hasattr(self.params, 'N_shots'):
+            self.params.N_shots = n_new // nrep if nrep > 0 else n_new
+
+    # ------------------------------------------------------------------
+    # Ragged-repeat-aware statistics (avg / std / sem by unique xvar value)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _stat_skip_keys():
+        """Attributes that must never be treated as reducible scan-shaped
+        data when building or collapsing statistics."""
+        return {
+            'avg', 'std', 'sem',
+            '_repeat_sem_source', '_repeat_sem_divisor',
+            'params', 'p', 'camera_params', 'run_info', 'roi',
+            'data', 'scope_data', '_analysis_tags', '_dealer',
+            '_ds', 'server_talk',
+            'shot_run_id', 'source_run_ids', 'source_repeat_counts',
+            'param_disagreements', 'sort_idx', 'sort_N',
+            'xvars', 'xvarnames', 'xvardims',
+        }
+
+    @staticmethod
+    def _grouped_mean_std(arr, inverse, n_groups, counts):
+        """NaN-aware group mean/std along axis 0 by ``inverse`` group labels.
+
+        Returns population std (ddof=0), matching the base atomdata repeat
+        statistics. NaN entries (e.g. from NaN-padded DataVault keys that are
+        absent in some runs) are ignored per element.
+        """
+        arr = np.asarray(arr, dtype=np.float64)
+        trailing = arr.shape[1:]
+        shp = (n_groups,) + trailing
+        finite = np.isfinite(arr)
+        vals = np.where(finite, arr, 0.0)
+        csum = np.zeros(shp, dtype=np.float64)
+        sqsum = np.zeros(shp, dtype=np.float64)
+        ncnt = np.zeros(shp, dtype=np.float64)
+        np.add.at(csum, inverse, vals)
+        np.add.at(sqsum, inverse, vals * vals)
+        np.add.at(ncnt, inverse, finite.astype(np.float64))
+        with np.errstate(invalid='ignore', divide='ignore'):
+            mean = csum / ncnt
+            var = sqsum / ncnt - mean * mean
+        var = np.clip(var, 0.0, None)
+        std = np.sqrt(var)
+        return mean, std
+
+    @staticmethod
+    def _sem_from_std(std, counts):
+        n = np.asarray(counts, dtype=np.float64)
+        shp = (std.shape[0],) + (1,) * (std.ndim - 1)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            return std / np.sqrt(n).reshape(shp)
+
+    def _copy_metadata_to_ragged_sibling(self, ad_out, unique_xvar):
+        """Populate a stat-sibling object (avg/std/sem) with metadata whose
+        single scan axis is the *unique* xvar values."""
+        ad_out._lite = self._lite
+        ad_out.server_talk = self.server_talk
+        ad_out._ds = getattr(self, '_ds', None)
+        ad_out._dealer = None
+        ad_out.images = self.images
+        ad_out.image_timestamps = self.image_timestamps
+        ad_out.experiment_code = getattr(self, 'experiment_code', None)
+
+        ad_out.params = copy.deepcopy(self.params)
+        ad_out.p = ad_out.params
+        ad_out.camera_params = copy.deepcopy(self.camera_params)
+        ad_out.run_info = copy.deepcopy(self.run_info)
+        ad_out.roi = copy.deepcopy(self.roi)
+
+        ad_out.xvarnames = list(self.xvarnames)
+        ad_out.xvars = [np.array(unique_xvar, copy=True)]
+        ad_out.Nvars = 1
+        ad_out.xvardims = np.array([len(unique_xvar)], dtype=int)
+        setattr(ad_out.params, ad_out.xvarnames[0], ad_out.xvars[0])
+        ad_out.params.N_repeats = 1
+
+        ad_out.sort_idx = np.array([])
+        ad_out.sort_N = np.array([])
+
+        ad_out.data = _VaultDataVault()
+        ad_out.avg = None
+        ad_out.std = None
+        ad_out.sem = None
+        ad_out._repeat_sem_source = None
+        ad_out._repeat_sem_divisor = None
+        ad_out._repeat_lazy_stat_context = None
+        ad_out.source_run_ids = list(getattr(self, 'source_run_ids', []))
+
+        ad_out._analysis_tags = analysis_tags(
+            self._analysis_tags.roi_id, self._analysis_tags.imaging_type
+        )
+        ad_out._analysis_tags.xvars_shuffled = False
+
+    def _build_grouped_statistics(self):
+        """Build eager avg/std/sem siblings by grouping shots by unique xvar
+        value. Handles ragged repeat counts (overlapping ranges) and uses each
+        point's own count for SEM."""
+        xvar = np.asarray(self.xvars[0])
+        unique, inverse, counts = np.unique(
+            xvar, return_inverse=True, return_counts=True
+        )
+        inverse = np.asarray(inverse).ravel()
+        n_groups = unique.size
+
+        ad_avg = object.__new__(self.__class__)
+        ad_std = object.__new__(self.__class__)
+        ad_sem = object.__new__(self.__class__)
+        for sib in (ad_avg, ad_std, ad_sem):
+            self._copy_metadata_to_ragged_sibling(sib, unique)
+
+        skip = self._stat_skip_keys()
+
+        def _reduce(value):
+            mean, std = self._grouped_mean_std(value, inverse, n_groups, counts)
+            sem = self._sem_from_std(std, counts)
+            return mean, std, sem
+
+        # Top-level scan-shaped arrays (od, od_raw, atom_number, fits, ...).
+        for key, value in vars(self).items():
+            if key in skip or key.startswith('_'):
+                continue
+            if self._is_scan_shaped_numeric_array(value):
+                mean, std, sem = _reduce(value)
+                vars(ad_avg)[key] = mean
+                vars(ad_std)[key] = std
+                vars(ad_sem)[key] = sem
+            else:
+                for sib in (ad_avg, ad_std, ad_sem):
+                    if key not in vars(sib):
+                        vars(sib)[key] = value
+
+        # DataVault container.
+        for key in self.data.keys:
+            value = vars(self.data)[key]
+            if self._is_scan_shaped_numeric_array(value):
+                mean, std, sem = _reduce(value)
+                vars(ad_avg.data)[key] = mean
+                vars(ad_std.data)[key] = std
+                vars(ad_sem.data)[key] = sem
+            else:
+                for sib in (ad_avg, ad_std, ad_sem):
+                    vars(sib.data)[key] = value
+            for sib in (ad_avg, ad_std, ad_sem):
+                sib.data.keys.append(key)
+
+        # Scope data (best effort; large arrays).
+        if hasattr(self, 'scope_data'):
+            from waxa.atomdata_base import ScopeTraceArray
+            avg_scope, std_scope, sem_scope = {}, {}, {}
+            try:
+                for scope_key, ch_dict in self.scope_data.items():
+                    avg_scope[scope_key] = {}
+                    std_scope[scope_key] = {}
+                    sem_scope[scope_key] = {}
+                    for ch, trace in ch_dict.items():
+                        out = {'t': {}, 'v': {}}
+                        for ax in ('t', 'v'):
+                            val = np.asarray(getattr(trace, ax))
+                            if self._is_scan_shaped_numeric_array(val):
+                                mean, std, sem = _reduce(val)
+                            else:
+                                mean = std = sem = val
+                            out[ax] = (mean, std, sem)
+                        avg_scope[scope_key][ch] = ScopeTraceArray(
+                            scope_key, ch, out['t'][0], out['v'][0])
+                        std_scope[scope_key][ch] = ScopeTraceArray(
+                            scope_key, ch, out['t'][1], out['v'][1])
+                        sem_scope[scope_key][ch] = ScopeTraceArray(
+                            scope_key, ch, out['t'][2], out['v'][2])
+                ad_avg.scope_data = avg_scope
+                ad_std.scope_data = std_scope
+                ad_sem.scope_data = sem_scope
+            except Exception as e:
+                warnings.warn(
+                    f"AtomdataVault: failed to reduce scope_data statistics "
+                    f"({e}); scope stats unavailable.",
+                    stacklevel=2,
+                )
+
+        self.avg = ad_avg
+        self.std = ad_std
+        self.sem = ad_sem
+        self._repeat_lazy_stat_context = None
+
+    def _refresh_repeat_statistics(self):
+        """Override: group by unique xvar value so overlapping ranges with
+        ragged repeat counts average correctly."""
+        if not self._merge_overlap:
+            return atomdata_base._refresh_repeat_statistics(self)
+        self._build_grouped_statistics()
+
+    # ------------------------------------------------------------------
+    # Collapsing / provenance / auditing
+    # ------------------------------------------------------------------
+    def collapse_to_unique(self, reanalyze=True):
+        """Permanently collapse the vault onto its unique xvar values, averaging
+        all repeats/overlaps. Analogous to ``avg_repeats`` but ragged-safe.
+
+        Parameters
+        ----------
+        reanalyze : bool
+            If True (default) and the raw OD is available, re-run ``analyze_ods``
+            so fits/atom-number are recomputed from the collapsed OD.
+        """
+        if getattr(self._analysis_tags, 'averaged', False):
+            print('AtomdataVault is already collapsed to unique xvar values.')
+            return self
+
+        xvar = np.asarray(self.xvars[0])
+        unique, inverse, counts = np.unique(
+            xvar, return_inverse=True, return_counts=True
+        )
+        inverse = np.asarray(inverse).ravel()
+        n_groups = unique.size
+
+        skip = self._stat_skip_keys()
+        for key, value in list(vars(self).items()):
+            if key in skip or key.startswith('_'):
+                continue
+            if self._is_scan_shaped_numeric_array(value):
+                mean, _ = self._grouped_mean_std(value, inverse, n_groups, counts)
+                vars(self)[key] = mean
+
+        for key in self.data.keys:
+            value = vars(self.data)[key]
+            if self._is_scan_shaped_numeric_array(value):
+                mean, _ = self._grouped_mean_std(value, inverse, n_groups, counts)
+                vars(self.data)[key] = mean
+
+        if hasattr(self, 'scope_data'):
+            for scope_key, ch_dict in self.scope_data.items():
+                for ch, trace in ch_dict.items():
+                    for ax in ('t', 'v'):
+                        val = np.asarray(getattr(trace, ax))
+                        if self._is_scan_shaped_numeric_array(val):
+                            mean, _ = self._grouped_mean_std(
+                                val, inverse, n_groups, counts)
+                            setattr(trace, ax, mean)
+
+        # Collapse provenance to the set of runs contributing to each point.
+        if hasattr(self, 'shot_run_id') and np.asarray(self.shot_run_id).dtype != object:
+            rid = np.asarray(self.shot_run_id)
+            self.shot_run_id = np.array(
+                [np.unique(rid[inverse == g]) for g in range(n_groups)],
+                dtype=object,
+            )
+
+        # Raw images no longer line up with the collapsed axis.
+        if self._has_images:
+            self.images = np.array([])
+            self.image_timestamps = np.array([])
+
+        self.xvars[0] = unique
+        setattr(self.params, self.xvarnames[0], unique)
+        self.xvardims = np.array([n_groups], dtype=int)
+        self.params.N_repeats = 1
+        self.params.N_shots_with_repeats = n_groups
+        if hasattr(self.params, 'N_shots'):
+            self.params.N_shots = n_groups
+        self._analysis_tags.averaged = True
+
+        if reanalyze and 'od_raw' in vars(self):
+            self.analyze_ods()
+        self._refresh_repeat_statistics()
+        return self
+
+    def shots_from_run(self, run_id):
+        """Boolean mask selecting the shots that came from ``run_id``."""
+        rid = np.asarray(self.shot_run_id)
+        if rid.dtype == object:
+            raise RuntimeError(
+                'Per-shot provenance is unavailable after collapse_to_unique.'
+            )
+        return rid == int(run_id)
+
+    def drop_runs(self, run_ids, reanalyze=True):
+        """Remove every shot belonging to ``run_ids`` and refresh statistics.
+
+        Useful for excluding an outlier/aborted run discovered after loading.
+        """
+        if np.isscalar(run_ids):
+            run_ids = [run_ids]
+        drop = {int(r) for r in run_ids}
+
+        if not hasattr(self, 'shot_run_id'):
+            raise RuntimeError('shot_run_id provenance is unavailable.')
+        rid = np.asarray(self.shot_run_id)
+        if rid.dtype == object:
+            raise RuntimeError(
+                'drop_runs is unavailable after collapse_to_unique.'
+            )
+
+        keep = np.where(~np.isin(rid, list(drop)))[0]
+        if keep.size == rid.size:
+            warnings.warn(
+                'AtomdataVault.drop_runs: no shots matched the requested run '
+                f'ids {sorted(drop)}.',
+                stacklevel=2,
+            )
+            return self
+        if keep.size == 0:
+            raise ValueError('drop_runs would remove every shot in the vault.')
+
+        self._reorder_shots(keep)
+        self.source_run_ids = [r for r in self.source_run_ids if r not in drop]
+
+        if reanalyze and 'od_raw' in vars(self):
+            self.analyze_ods()
+        self._refresh_repeat_statistics()
+        return self
+
+    @staticmethod
+    def _fmt_param_value(value):
+        if value is None:
+            return 'NA'
+        arr = np.asarray(value)
+        if arr.ndim == 0:
+            try:
+                return f'{float(arr):.6g}'
+            except (TypeError, ValueError):
+                return str(value)
+        if arr.size <= 4 and np.issubdtype(arr.dtype, np.number):
+            return '[' + ', '.join(f'{v:.4g}' for v in arr.ravel()) + ']'
+        return f'<{arr.dtype} array shape {arr.shape}>'
+
+    def param_report(self):
+        """Print a per-run summary of the source runs and any fixed-parameter
+        disagreements. Returns the disagreements dict."""
+        rids = list(self.source_run_ids)
+        lines = [f'AtomdataVault: {len(rids)} source run(s)']
+        lines.append('  run_ids: ' + ', '.join(str(r) for r in rids))
+
+        rc = getattr(self, 'source_repeat_counts', None)
+        if rc:
+            lines.append('  N_repeats: '
+                         + ', '.join(f'{r}:{rc.get(r, "?")}' for r in rids))
+
+        if not self.param_disagreements:
+            lines.append('  All fixed parameters agree across runs.')
+        else:
+            lines.append(f'  {len(self.param_disagreements)} fixed parameter(s) '
+                         f'disagree across runs:')
+            for key in sorted(self.param_disagreements):
+                per_run = self.param_disagreements[key]
+                vals = ', '.join(
+                    f'{r}={self._fmt_param_value(per_run.get(r))}' for r in rids
+                )
+                lines.append(f'    {key}: {vals}')
+
+        print('\n'.join(lines))
+        return self.param_disagreements
+
+    def add_runs(self, inputs, **overrides):
+        """Return a NEW vault built from this vault's source runs plus
+        ``inputs`` (run-ids or atomdata objects). Construction options are
+        inherited from this vault unless overridden via keyword arguments."""
+        kwargs = dict(self._build_kwargs)
+        kwargs.update(overrides)
+        combined = list(self.source_run_ids) + _flatten_inputs(inputs)
+        return AtomdataVault(combined, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Builder-aware discovery constructors
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_run_range(cls, start_id, stop_id, experiment_name=None,
+                       skip_missing=True, roi_id=None, lite=True, **kwargs):
+        """Build a vault from a contiguous run-id range ``[start_id, stop_id]``.
+
+        Missing/aborted run-ids are skipped (``skip_missing``). If
+        ``experiment_name`` is given, only runs whose experiment class or
+        filepath contains that substring are kept -- handy for an experiment
+        builder that interleaves several experiment types. Subsequent runs
+        reuse the first loaded run's ROI so the selector opens at most once.
+        """
+        start_id, stop_id = int(start_id), int(stop_id)
+        if stop_id < start_id:
+            start_id, stop_id = stop_id, start_id
+
+        ads, skipped = [], []
+        anchor_roi = roi_id
+        for rid in range(start_id, stop_id + 1):
+            try:
+                ad = atomdata(rid, roi_id=anchor_roi, lite=lite)
+            except Exception:
+                if skip_missing:
+                    skipped.append(rid)
+                    continue
+                raise
+            if anchor_roi is None:
+                anchor_roi = int(ad.run_info.run_id)
+                try:
+                    ad.save_roi_h5()
+                except Exception:
+                    pass
+            if experiment_name is not None:
+                name = str(getattr(ad.run_info, 'expt_class', '') or '')
+                fpath = str(getattr(ad.run_info, 'experiment_filepath', '') or '')
+                target = experiment_name.lower()
+                if target not in name.lower() and target not in fpath.lower():
+                    skipped.append(rid)
+                    continue
+            ads.append(ad)
+
+        if not ads:
+            raise ValueError(
+                f'No loadable runs found in range [{start_id}, {stop_id}]'
+                + (f' matching experiment_name={experiment_name!r}'
+                   if experiment_name else '') + '.'
+            )
+        if skipped:
+            preview = ', '.join(str(r) for r in skipped[:20])
+            more = '...' if len(skipped) > 20 else ''
+            warnings.warn(
+                f'AtomdataVault.from_run_range: skipped {len(skipped)} run(s) '
+                f'({preview}{more}).',
+                stacklevel=2,
+            )
+        return cls(ads, roi_id=roi_id, lite=lite, **kwargs)
+
+    @classmethod
+    def from_builder(cls, start_id, stop_id, experiment_name, **kwargs):
+        """Convenience wrapper around :meth:`from_run_range` that requires an
+        ``experiment_name`` filter -- the typical experiment-builder case where
+        a run-id range contains the builder's runs (possibly interleaved with
+        others)."""
+        return cls.from_run_range(
+            start_id, stop_id, experiment_name=experiment_name, **kwargs
+        )
 
     # ------------------------------------------------------------------
     # Unsupported operations

--- a/waxa-src/waxa/atomdata_vault.py
+++ b/waxa-src/waxa/atomdata_vault.py
@@ -117,6 +117,11 @@ class AtomdataVault(atomdata_base):
         If set and more than this many run-ids are passed (and ``lite`` is
         False), automatically load them ``lite`` and emit a warning. Defaults
         to 8. Pass ``None`` to disable.
+    ignore_images : bool
+        If True, camera images are not loaded/concatenated and no ROI is
+        created. Only the non-image data (params, DataVault fields,
+        scope_data, xvars) is stitched together. Image-based analysis is
+        skipped and image-derived attributes are set to ``None``.
     """
 
     def __init__(self,
@@ -127,10 +132,12 @@ class AtomdataVault(atomdata_base):
                  sort=True,
                  merge_overlap=True,
                  drop_raw_images=False,
-                 auto_lite_threshold=8):
+                 auto_lite_threshold=8,
+                 ignore_images=False):
 
         # Lightweight book-keeping expected by inherited helpers.
         self._lite = lite
+        self._ignore_images = bool(ignore_images)
         self._timing_enabled = False
         self._timing = {}
         self.server_talk = None
@@ -203,22 +210,24 @@ class AtomdataVault(atomdata_base):
                     _first_run_id = int(item.run_info.run_id)
                     # Save the ROI so subsequent int loads (and lite-dataset
                     # creation) can look it up by run_id.
-                    if _has_subsequent_int_loads or lite:
+                    if (not self._ignore_images) and (_has_subsequent_int_loads or lite):
                         item.save_roi_h5()
             elif isinstance(item, (int, np.integer)):
                 # First int load: use caller-supplied roi_id (may open GUI once).
                 # Subsequent int loads: reuse the first run's roi_id so no
                 # additional GUI opens.
                 if _first_run_id is None:
-                    ad = atomdata(int(item), roi_id=roi_id, lite=lite)
+                    ad = atomdata(int(item), roi_id=roi_id, lite=lite,
+                                  no_images=self._ignore_images)
                     _first_run_id = int(ad.run_info.run_id)
                     # Persist the ROI so subsequent int loads (and lite-dataset
                     # creation for each run) can find it by run_id.
-                    if _has_subsequent_int_loads or lite:
+                    if (not self._ignore_images) and (_has_subsequent_int_loads or lite):
                         ad.save_roi_h5()
                 else:
                     _roi = roi_id if roi_id is not None else _first_run_id
-                    ad = atomdata(int(item), roi_id=_roi, lite=lite)
+                    ad = atomdata(int(item), roi_id=_roi, lite=lite,
+                                  no_images=self._ignore_images)
                 ads.append(ad)
             else:
                 raise TypeError(
@@ -231,6 +240,7 @@ class AtomdataVault(atomdata_base):
         self._validate_inputs(
             ads, xvarname_override,
             allow_repeat_mismatch=self._merge_overlap,
+            ignore_images=self._ignore_images,
         )
 
         # 3. Unshuffle each chunk so the per-shot arrays are in xvar order on
@@ -260,7 +270,10 @@ class AtomdataVault(atomdata_base):
         self.camera_params = copy.deepcopy(first.camera_params)
         self.run_info = copy.deepcopy(first.run_info)
         self.experiment_code = getattr(first, 'experiment_code', None)
-        self._has_images = bool(getattr(first, '_has_images', True))
+        self._has_images = (
+            False if self._ignore_images
+            else bool(getattr(first, '_has_images', True))
+        )
 
         self._warn_param_mismatches(chunks)
 
@@ -338,23 +351,38 @@ class AtomdataVault(atomdata_base):
         )
         self._analysis_tags.xvars_shuffled = False
 
-        # ROI: pass only the first chunk's images for display/selection so the
-        # GUI shows a representative frame from the first run, not all runs.
-        # The resulting roix/roiy coordinates are then applied to the full
-        # concatenated od_raw during analyze_ods.
+        # ROI: reuse the first chunk's already-resolved ROI so all runs are
+        # cropped with exactly the ROI chosen for the first run (loaded from
+        # its h5 file, or selected via the GUI at load time). This guarantees
+        # a single, consistent ROI across every run without re-opening the
+        # selection GUI. The resulting roix/roiy coordinates are applied to
+        # the full concatenated od_raw during analyze_ods.
         if self._has_images:
-            roi_source = roi_id if roi_id is not None else int(first.run_info.run_id)
-            self.roi = ROI(
-                run_id=int(first.run_info.run_id),
-                roi_id=roi_source,
-                use_saved_roi=True,
-                lite=self._lite,
-                server_talk=None,
-                current_file_path=None,
-                current_saved_roi=None,
-                images=_first_chunk_images,
-                imaging_type=self.run_info.imaging_type,
-            )
+            first_roi = getattr(first, 'roi', None)
+            if first_roi is not None:
+                self.roi = copy.deepcopy(first_roi)
+                # Point the ROI at the first chunk's frame for any later GUI
+                # display (e.g. recrop) and at the first run's id.
+                self.roi._images = _first_chunk_images
+                self.roi.run_id = int(first.run_info.run_id)
+                self.roi._current_file_path = None
+                self.roi._current_saved_roi = [self.roi.roix, self.roi.roiy]
+            else:
+                roi_source = (
+                    roi_id if roi_id is not None
+                    else int(first.run_info.run_id)
+                )
+                self.roi = ROI(
+                    run_id=int(first.run_info.run_id),
+                    roi_id=roi_source,
+                    use_saved_roi=True,
+                    lite=self._lite,
+                    server_talk=None,
+                    current_file_path=None,
+                    current_saved_roi=None,
+                    images=_first_chunk_images,
+                    imaging_type=self.run_info.imaging_type,
+                )
         else:
             self.roi = None
 
@@ -384,7 +412,7 @@ class AtomdataVault(atomdata_base):
     # ------------------------------------------------------------------
     # Validation helpers
     # ------------------------------------------------------------------
-    def _validate_inputs(self, ads, xvarname_override, allow_repeat_mismatch=False):
+    def _validate_inputs(self, ads, xvarname_override, allow_repeat_mismatch=False, ignore_images=False):
         first = ads[0]
 
         if int(getattr(first, 'Nvars', 0)) != 1:
@@ -399,7 +427,7 @@ class AtomdataVault(atomdata_base):
         first_has_images = bool(getattr(first, '_has_images', True))
         first_img_shape = (
             tuple(np.asarray(first.images).shape[1:])
-            if first_has_images else None
+            if (first_has_images and not ignore_images) else None
         )
 
         repeat_counts = {int(first.run_info.run_id): first_nrep}
@@ -430,6 +458,10 @@ class AtomdataVault(atomdata_base):
                 raise ValueError(
                     f"imaging_type mismatch on run {ad.run_info.run_id}."
                 )
+            # Image presence/shape checks are irrelevant when images are
+            # ignored entirely.
+            if ignore_images:
+                continue
             ad_has_images = bool(getattr(ad, '_has_images', True))
             if ad_has_images != first_has_images:
                 raise ValueError(
@@ -1127,6 +1159,38 @@ class AtomdataVault(atomdata_base):
         return cls.from_run_range(
             start_id, stop_id, experiment_name=experiment_name, **kwargs
         )
+
+    # ------------------------------------------------------------------
+    # ROI / recrop
+    # ------------------------------------------------------------------
+    def recrop(self, roi_id=None, use_saved=False):
+        """Select a new ROI and re-crop every concatenated run at once.
+
+        Because the vault stores the concatenated ``od_raw`` for all runs on
+        a single leading axis, cropping with one ROI naturally re-crops every
+        run identically.
+
+        Args:
+            roi_id (None, int, or str): See ``atomdata.recrop``. If None,
+                prompts the ROI selection GUI (unless a saved ROI is used).
+            use_saved (bool): If False (default), ignores any saved ROI and
+                forces selection of a new one.
+        """
+        if not getattr(self, '_has_images', True):
+            print("no images in dataset (ignore_images), no roi to crop")
+            return
+        if self._lite:
+            raise NotImplementedError(
+                "recrop is not supported on a lite AtomdataVault; the lite "
+                "runs are already cropped. Build the vault from full "
+                "(non-lite) runs to recrop all runs."
+            )
+        # od_raw is the concatenation of every run's raw ODs; selecting one
+        # ROI here and re-running analyze_ods re-crops all runs together.
+        od_flat = self.od_raw.reshape(-1, *self.od_raw.shape[-2:])
+        self.roi.load_roi(roi_id, use_saved, display_ods=od_flat)
+        self.analyze_ods()
+        self._refresh_repeat_statistics()
 
     # ------------------------------------------------------------------
     # Unsupported operations

--- a/waxx-src/waxx/base/scanner.py
+++ b/waxx-src/waxx/base/scanner.py
@@ -222,13 +222,11 @@ class Scanner():
 
         while scanning:
 
+            self.core.wait_until_mu(now_mu())
             aborted_bool = self._check_for_abort_signal()
             
-            self.core.wait_until_mu(now_mu())
             self.update_params_from_xvars()
-            delay(RPC_DELAY)
-
-            self.core.wait_until_mu(now_mu())
+            
             self.write_host_params_to_kernel()
             delay(RPC_DELAY)
             self.core.break_realtime()

--- a/waxx-src/waxx/config/data_vault.py
+++ b/waxx-src/waxx/config/data_vault.py
@@ -5,6 +5,24 @@ from artiq.language import delay, now_mu, kernel, TTuple, TBool
 from waxa.config.data_vault import DataContainer as DataContainerWaxa
 
 class DataContainer(DataContainerWaxa):
+    """Abstract base -- NEVER instantiate or place in a kernel list directly.
+
+    Holds only host-side logic (no @kernel methods). The concrete (ndim, dtype)
+    subclasses below each define their OWN copies of the kernel methods
+    (put_data / update_to_host / _put_shot_data). Those must NOT be factored up
+    here and inherited: ARTIQ caches a quoted function by identity and gives its
+    `self` a single TInstance, so a shared kernel method called on several
+    subclass instances (as DataVault.put_shot_data does) would fail to unify
+    either the `self` instance types or the differing `shot_data` array types.
+    Distinct per-subclass functions get type-checked independently against their
+    concrete attributes. The RPC targets below (update_from_kernel,
+    _put_shot_data_to_run_data) stay shared because their bodies run in CPython
+    and are never type-checked; only the per-subclass call sites are typed.
+    """
+    # Concrete subclasses override these. Kept here so the base is well-formed.
+    _NDIM = 1
+    _DTYPE = np.float64
+
     def __init__(self, per_shot_data_shape, dtype, external_data_bool, expt):
         self.key = ""
         self._per_shot_data_shape = tuple(np.atleast_1d(per_shot_data_shape))
@@ -13,10 +31,17 @@ class DataContainer(DataContainerWaxa):
         self._expt = expt
 
         self._data_gotten = False
+        # Sentinel = placeholder DataVault inserts to keep a per-type kernel list
+        # non-empty (ARTIQ cannot infer the element type of an empty object list).
+        # Its per-shot sync is a no-op (see each subclass's _put_shot_data), and
+        # it is never added to self.keys / saved.
+        self._is_sentinel = False
 
         self._run_data = np.zeros(per_shot_data_shape,dtype=dtype)
         self.shot_data = np.zeros(per_shot_data_shape,dtype=dtype)
         self._reference_data = copy.deepcopy(self.shot_data)
+
+    # ---- host-side only (RPC targets / setup); shared across subclasses ----
 
     def _put_shot_data_to_run_data(self):
         """Insert data into the array for the current shot.
@@ -35,15 +60,6 @@ class DataContainer(DataContainerWaxa):
                 else:
                     print(f"An error occurred with 'put_data' for data container '{self.key}':")
                     print(e)
-
-    @kernel
-    def put_data(self,value,idx=0):
-        self.shot_data[idx] = value
-
-    @kernel
-    def _put_shot_data(self):
-        self.update_to_host()
-        self._put_shot_data_to_run_data()
 
     def set_container_size(self):
         """Takes the per-shot data array and patterns it to the appropriate shape.
@@ -89,11 +105,106 @@ class DataContainer(DataContainerWaxa):
         if not self._data_gotten:
             self._data_gotten = not np.all(self.shot_data == self._reference_data)  
 
+
+# --- Concrete (ndim, dtype) subclasses ---------------------------------------
+# Each defines its OWN kernel methods (do not factor up into the base). The
+# bodies are identical text, but ARTIQ type-checks each separately against the
+# subclass's concrete shot_data type. Supported: 1D/2D of float64/int32/int64.
+
+class DataContainer1D_f64(DataContainer):
+    _NDIM, _DTYPE = 1, np.float64
+    @kernel
+    def put_data(self, value, idx=0):
+        self.shot_data[idx] = value
     @kernel
     def update_to_host(self):
-        """Necessary to sync up host and kernel.
-        """   
         self.update_from_kernel(self.shot_data)
+    @kernel
+    def _put_shot_data(self):
+        if self._is_sentinel:
+            return
+        self.update_to_host()
+        self._put_shot_data_to_run_data()
+
+class DataContainer2D_f64(DataContainer):
+    _NDIM, _DTYPE = 2, np.float64
+    @kernel
+    def put_data(self, value, idx=0):
+        # Element-wise row fill over the 2nd index (avoids multidim whole-row assignment).
+        for j in range(len(value)):
+            self.shot_data[idx, j] = value[j]
+    @kernel
+    def update_to_host(self):
+        self.update_from_kernel(self.shot_data)
+    @kernel
+    def _put_shot_data(self):
+        if self._is_sentinel:
+            return
+        self.update_to_host()
+        self._put_shot_data_to_run_data()
+
+class DataContainer1D_i32(DataContainer):
+    _NDIM, _DTYPE = 1, np.int32
+    @kernel
+    def put_data(self, value, idx=0):
+        self.shot_data[idx] = value
+    @kernel
+    def update_to_host(self):
+        self.update_from_kernel(self.shot_data)
+    @kernel
+    def _put_shot_data(self):
+        if self._is_sentinel:
+            return
+        self.update_to_host()
+        self._put_shot_data_to_run_data()
+
+class DataContainer2D_i32(DataContainer):
+    _NDIM, _DTYPE = 2, np.int32
+    @kernel
+    def put_data(self, value, idx=0):
+        for j in range(len(value)):
+            self.shot_data[idx, j] = value[j]
+    @kernel
+    def update_to_host(self):
+        self.update_from_kernel(self.shot_data)
+    @kernel
+    def _put_shot_data(self):
+        if self._is_sentinel:
+            return
+        self.update_to_host()
+        self._put_shot_data_to_run_data()
+
+class DataContainer1D_i64(DataContainer):
+    _NDIM, _DTYPE = 1, np.int64
+    @kernel
+    def put_data(self, value, idx=0):
+        self.shot_data[idx] = value
+    @kernel
+    def update_to_host(self):
+        self.update_from_kernel(self.shot_data)
+    @kernel
+    def _put_shot_data(self):
+        if self._is_sentinel:
+            return
+        self.update_to_host()
+        self._put_shot_data_to_run_data()
+
+class DataContainer2D_i64(DataContainer):
+    _NDIM, _DTYPE = 2, np.int64
+    @kernel
+    def put_data(self, value, idx=0):
+        for j in range(len(value)):
+            self.shot_data[idx, j] = value[j]
+    @kernel
+    def update_to_host(self):
+        self.update_from_kernel(self.shot_data)
+    @kernel
+    def _put_shot_data(self):
+        if self._is_sentinel:
+            return
+        self.update_to_host()
+        self._put_shot_data_to_run_data()
+
 
 class DataVault():
     
@@ -101,6 +212,31 @@ class DataVault():
         self.keys = []
         self._container_list = []
         self._expt = expt
+
+        # One homogeneous list per concrete (ndim, dtype). put_shot_data iterates
+        # each separately (a single ARTIQ loop variable may not change type), and
+        # each list is kept non-empty via a sentinel in init().
+        self._list_1d_f64 = []
+        self._list_2d_f64 = []
+        self._list_1d_i32 = []
+        self._list_2d_i32 = []
+        self._list_1d_i64 = []
+        self._list_2d_i64 = []
+
+        # (ndim, dtype_scalar_type) -> (class, per-type list). Host-only; never
+        # referenced in a kernel, so ARTIQ never tries to type it.
+        self._registry = {
+            (1, np.float64): (DataContainer1D_f64, self._list_1d_f64),
+            (2, np.float64): (DataContainer2D_f64, self._list_2d_f64),
+            (1, np.int32):   (DataContainer1D_i32, self._list_1d_i32),
+            (2, np.int32):   (DataContainer2D_i32, self._list_2d_i32),
+            (1, np.int64):   (DataContainer1D_i64, self._list_1d_i64),
+            (2, np.int64):   (DataContainer2D_i64, self._list_2d_i64),
+        }
+
+    @staticmethod
+    def _shape_ndim(per_shot_data_shape):
+        return len(tuple(np.atleast_1d(per_shot_data_shape)))
 
     def add_data_container(self,
                             per_shot_data_shape=(1,),
@@ -111,8 +247,15 @@ class DataVault():
         container the key used for the assignment during `finish_prepare` of
         an experiment.
 
+        Dispatches to the concrete container subclass matching (ndim, dtype),
+        where ndim is inferred from `per_shot_data_shape` (a 1-element shape ->
+        1D container, a 2-element shape -> 2D). Supported: 1D/2D of float64,
+        int32, int64.
+
         Example in `prepare`: for an experiment with DataVault object `self.data`:
-            self.data.my_data = self.data.add_data_container()
+            self.data.my_data = self.data.add_data_container()                 # 1D float64
+            self.data.counts  = self.data.add_data_container(8, np.int32)      # 1D int32, length 8
+            self.data.grid    = self.data.add_data_container((4, 8), np.int64) # 2D int64
 
         Example in `kexp.config.data_vault`: add to `__init__`
             self.my_data = self.add_data_container()
@@ -124,9 +267,11 @@ class DataVault():
 
         Args:
             per_shot_data_shape (tuple or array or int): Shape of the data per
-                shot. Defaults to (1,).
+                shot. A 1-element shape -> 1D container, a 2-element shape -> 2D.
+                Defaults to (1,).
             dtype (_type_, optional): Data type for each value in the data
-                array. Defaults to np.float64.
+                array. One of np.float64, np.int32, np.int64. Defaults to
+                np.float64.
             external_data_bool (bool, optional): Set to True if the data for
                 this container will be populated directly into the hdf5 data file by
                 a process external to the ARTIQ process. An example would be image
@@ -137,24 +282,57 @@ class DataVault():
                 zeros.) Defaults to False.
 
         Returns:
-            DataContainer: _description_
-        """        
-        return DataContainer(per_shot_data_shape,
-                            dtype,
-                            external_data_bool,
-                            self._expt)
+            DataContainer: a concrete (ndim, dtype) container subclass instance.
+        """
+        ndim = self._shape_ndim(per_shot_data_shape)
+        dtype_type = np.dtype(dtype).type
+        entry = self._registry.get((ndim, dtype_type))
+        if entry is None:
+            raise ValueError(
+                f"Unsupported data container (ndim={ndim}, dtype={np.dtype(dtype)}). "
+                f"Supported: 1D/2D of float64, int32, int64."
+            )
+        cls = entry[0]
+        return cls(per_shot_data_shape,
+                   dtype,
+                   external_data_bool,
+                   self._expt)
     
     def init(self):
         self.write_keys()
         self.set_container_sizes()
+        self._ensure_type_lists_nonempty()
 
     def write_keys(self):
-        for k in self.__dict__.keys():
+        for k in list(self.__dict__.keys()):
             obj = vars(self)[k]
             if isinstance(obj,DataContainer):
-                vars(self)[k].key = k
+                obj.key = k
                 self.keys.append(k)
                 self._container_list.append(obj)
+                self._route_to_type_list(obj)
+
+    def _route_to_type_list(self, dc):
+        """Append a real container to its concrete (ndim, dtype) kernel list."""
+        entry = self._registry.get((dc._NDIM, np.dtype(dc._DTYPE).type))
+        if entry is None:
+            raise ValueError(
+                f"Data container '{dc.key}' has unsupported type "
+                f"(ndim={dc._NDIM}, dtype={np.dtype(dc._DTYPE)})."
+            )
+        entry[1].append(dc)
+
+    def _ensure_type_lists_nonempty(self):
+        """For every type the experiment did not use, insert one no-op sentinel
+        so its kernel list is non-empty (ARTIQ cannot infer the element type of
+        an empty object list, and put_shot_data iterates all six lists). The
+        sentinel matches the subclass ndim/dtype and is never saved."""
+        for (ndim, dtype_type), (cls, lst) in self._registry.items():
+            if len(lst) == 0:
+                shape = (1,) if ndim == 1 else (1, 1)
+                sentinel = cls(shape, dtype_type, False, self._expt)
+                sentinel._is_sentinel = True
+                lst.append(sentinel)
 
     def set_container_sizes(self):
         for key in self.keys:
@@ -164,8 +342,21 @@ class DataVault():
 
     @kernel
     def put_shot_data(self):
-        # self._put_shot_data_rpc()
+        # Iterate each per-type list with a distinctly named loop variable: an
+        # ARTIQ variable may not change type between loops. Every list is
+        # non-empty (sentinels), and each subclass has its own _put_shot_data,
+        # so no cross-type unification occurs.
         self._expt.core.wait_until_mu(now_mu())
-        for dc in self._container_list:
-            dc._put_shot_data()
+        for dc_1d_f64 in self._list_1d_f64:
+            dc_1d_f64._put_shot_data()
+        for dc_2d_f64 in self._list_2d_f64:
+            dc_2d_f64._put_shot_data()
+        for dc_1d_i32 in self._list_1d_i32:
+            dc_1d_i32._put_shot_data()
+        for dc_2d_i32 in self._list_2d_i32:
+            dc_2d_i32._put_shot_data()
+        for dc_1d_i64 in self._list_1d_i64:
+            dc_1d_i64._put_shot_data()
+        for dc_2d_i64 in self._list_2d_i64:
+            dc_2d_i64._put_shot_data()
         self._expt.core.break_realtime()

--- a/waxx-src/waxx/config/data_vault.py
+++ b/waxx-src/waxx/config/data_vault.py
@@ -113,12 +113,20 @@ class DataContainer(DataContainerWaxa):
 
 class DataContainer1D_f64(DataContainer):
     _NDIM, _DTYPE = 1, np.float64
+
     @kernel
-    def put_data(self, value, idx=0):
-        self.shot_data[idx] = value
+    def put_data(self, value, i=0):
+        self.shot_data[i] = value
+
+    @kernel
+    def put_data_row(self, value):
+        for j in range(len(value)):
+            self.shot_data[j] = value[j]
+
     @kernel
     def update_to_host(self):
         self.update_from_kernel(self.shot_data)
+
     @kernel
     def _put_shot_data(self):
         if self._is_sentinel:
@@ -128,14 +136,26 @@ class DataContainer1D_f64(DataContainer):
 
 class DataContainer2D_f64(DataContainer):
     _NDIM, _DTYPE = 2, np.float64
+
     @kernel
-    def put_data(self, value, idx=0):
-        # Element-wise row fill over the 2nd index (avoids multidim whole-row assignment).
+    def put_data(self, value, i=0, j=0):
+        self.shot_data[i, j] = value
+
+    @kernel
+    def put_data_row(self, value, i=0):
         for j in range(len(value)):
-            self.shot_data[idx, j] = value[j]
+            self.shot_data[i, j] = value[j]
+
+    @kernel
+    def put_data_array(self, value):
+        for i in range(len(value)):
+            for j in range(len(value[i])):
+                self.shot_data[i, j] = value[i,j]
+
     @kernel
     def update_to_host(self):
         self.update_from_kernel(self.shot_data)
+
     @kernel
     def _put_shot_data(self):
         if self._is_sentinel:
@@ -145,12 +165,20 @@ class DataContainer2D_f64(DataContainer):
 
 class DataContainer1D_i32(DataContainer):
     _NDIM, _DTYPE = 1, np.int32
+
     @kernel
-    def put_data(self, value, idx=0):
-        self.shot_data[idx] = value
+    def put_data(self, value, i=0):
+        self.shot_data[i] = value
+
+    @kernel
+    def put_data_row(self, value):
+        for j in range(len(value)):
+            self.shot_data[j] = value[j]
+
     @kernel
     def update_to_host(self):
         self.update_from_kernel(self.shot_data)
+
     @kernel
     def _put_shot_data(self):
         if self._is_sentinel:
@@ -160,13 +188,26 @@ class DataContainer1D_i32(DataContainer):
 
 class DataContainer2D_i32(DataContainer):
     _NDIM, _DTYPE = 2, np.int32
+
     @kernel
-    def put_data(self, value, idx=0):
+    def put_data(self, value, i=0, j=0):
+        self.shot_data[i, j] = value
+
+    @kernel
+    def put_data_row(self, value, i=0):
         for j in range(len(value)):
-            self.shot_data[idx, j] = value[j]
+            self.shot_data[i, j] = value[j]
+
+    @kernel
+    def put_data_array(self, value):
+        for i in range(len(value)):
+            for j in range(len(value[i])):
+                self.shot_data[i, j] = value[i,j]
+
     @kernel
     def update_to_host(self):
         self.update_from_kernel(self.shot_data)
+
     @kernel
     def _put_shot_data(self):
         if self._is_sentinel:
@@ -176,12 +217,20 @@ class DataContainer2D_i32(DataContainer):
 
 class DataContainer1D_i64(DataContainer):
     _NDIM, _DTYPE = 1, np.int64
+
     @kernel
-    def put_data(self, value, idx=0):
-        self.shot_data[idx] = value
+    def put_data(self, value, i=0):
+        self.shot_data[i] = value
+
+    @kernel
+    def put_data_row(self, value):
+        for j in range(len(value)):
+            self.shot_data[j] = value[j]
+
     @kernel
     def update_to_host(self):
         self.update_from_kernel(self.shot_data)
+
     @kernel
     def _put_shot_data(self):
         if self._is_sentinel:
@@ -191,13 +240,26 @@ class DataContainer1D_i64(DataContainer):
 
 class DataContainer2D_i64(DataContainer):
     _NDIM, _DTYPE = 2, np.int64
+
     @kernel
-    def put_data(self, value, idx=0):
+    def put_data(self, value, i=0, j=0):
+        self.shot_data[i, j] = value
+
+    @kernel
+    def put_data_row(self, value, i=0):
         for j in range(len(value)):
-            self.shot_data[idx, j] = value[j]
+            self.shot_data[i, j] = value[j]
+
+    @kernel
+    def put_data_array(self, value):
+        for i in range(len(value)):
+            for j in range(len(value[i])):
+                self.shot_data[i, j] = value[i,j]
+
     @kernel
     def update_to_host(self):
         self.update_from_kernel(self.shot_data)
+
     @kernel
     def _put_shot_data(self):
         if self._is_sentinel:


### PR DESCRIPTION
update data containers to support arbitrary dimensions. currently implemented:
- float64 1d and 2d arrays
- float32 1d and 2d arrays
- int64 1d and 2d arrays
- int32 1d and 2d arrays

Updated AtomdataVault class to load multiple run IDs as as single atomdata and concatenate their xvars. Has basic warnings for when non-xvar arrays different between runs, but otherwise allows loading in case this is intentional.

Added "ignore_images" flag to `atomdata` and `AtomdataVault` to load a dataset with no images, for historical/accidental runs that have image data but we don't want to waste the RAM / time loading images.